### PR TITLE
Feature/add column on validation error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clu-clu",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "main": "lib/cjs/index.js",
   "types": "lib/index.d.ts",
   "scripts": {

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -8,6 +8,7 @@ export interface Validation {
 
 export interface ValidationError {
   message: string;
+  column?: string;
 }
 
 export type ValidationColumn<K> = { [V in keyof K]?: ValidationType };
@@ -45,5 +46,8 @@ const validators = (
   value: unknown
 ): ValidationError[] =>
   Object.values(validationTypes.types)
-    .map((type) => Validator[type](column, value, validationTypes.displayName))
+    .map((type) => ({
+      ...Validator[type](column, value, validationTypes.displayName),
+      column: column
+    }))
     .filter(notEmpty);

--- a/src/validation/mock.ts
+++ b/src/validation/mock.ts
@@ -11,6 +11,7 @@ export function createMockValidation(isValid: boolean): Validation {
         errors: [
           {
             message: "error message",
+            column: "name"
           },
         ],
       };

--- a/src/validation/validators/localization/ja.ts
+++ b/src/validation/validators/localization/ja.ts
@@ -8,6 +8,12 @@ export const dictionary = (column: string): string => {
       return "氏名";
     case "kanaName":
       return "氏名(かな)";
+    case "carMakeName":
+      return "カーメーカー";
+    case "carModelName":
+      return "車種";
+    case "carModelNumber":
+      return "型式";
     default:
       return column;
   }


### PR DESCRIPTION
close: https://github.com/seibii/clu-clu/issues/36

## What
- `ValidationError`に columnを追加

## 変更理由
- 画像のようにエラーメッセージが返ってくるが、どれに対するエラーメッセージか分からないため

<kbd><img width="395" alt="スクリーンショット 2021-10-07 21 16 08" src="https://user-images.githubusercontent.com/33958130/136382222-7d32f93c-5626-4a81-9865-99c84cf461c4.png"></kbd>

## 変更後
- 変更後は下記画像のような形で返ってきます
<kbd><img width="543" alt="スクリーンショット 2021-10-07 21 17 46" src="https://user-images.githubusercontent.com/33958130/136382503-afcf7aec-fae2-4878-ae4d-b466682f4c71.png"></kbd>

## 用途
- 下記のfigmaみたいに、inputごとにエラーメッセージを表示したいときに使います。
[figma](https://www.figma.com/file/J5ICinDhax9OUe0YuVa8gu/App---Web%EF%BC%88Mobile%EF%BC%89?node-id=44%3A2300)
