### PR TITLE
Feature/add location and pageEvent mock

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clu-clu",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "main": "lib/cjs/index.js",
   "types": "lib/index.d.ts",
   "scripts": {

--- a/src/testHelpers/mockSources/index.ts
+++ b/src/testHelpers/mockSources/index.ts
@@ -9,3 +9,5 @@ export * from "./modalActions";
 export * from "./router";
 export * from "./shaken";
 export * from "./storage";
+export * from "./location";
+export * from "./pageEvent";

--- a/src/testHelpers/mockSources/location.ts
+++ b/src/testHelpers/mockSources/location.ts
@@ -1,0 +1,11 @@
+import { Stream } from "xstream";
+
+export interface MockLocationSource {
+  href$?: Stream<string>;
+}
+
+export const mockLocationSource = (source: {
+  href$?: Stream<string>;
+}): MockLocationSource => ({
+  href$: source.href$ || Stream.never(),
+});

--- a/src/testHelpers/mockSources/pageEvent.ts
+++ b/src/testHelpers/mockSources/pageEvent.ts
@@ -1,0 +1,12 @@
+import { Stream } from "xstream";
+import { PageEvent } from "../../drivers/pageEventDriver";
+
+export interface MockPageEventSource {
+  event$?: Stream<PageEvent>;
+}
+
+export const mockPageEventSource = (source: {
+  event$?: Stream<PageEvent>;
+}): MockPageEventSource => ({
+  event$: source.event$ || Stream.never(),
+});


### PR DESCRIPTION
## What
- `location`と`pageEvent`のmockSourceを追加

## 追加理由
-下記PRでテストが落ちるため追加
  https://github.com/seibii/seibii-frontend-customer/pull/1071

## その他
- ローカルでテストが通ることは確認しました。