### PR TITLE
:+1: Added window support to scrolTopDriver

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clu-clu",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "main": "lib/cjs/index.js",
   "types": "lib/index.d.ts",
   "scripts": {

--- a/src/drivers/scrollTopDriver.ts
+++ b/src/drivers/scrollTopDriver.ts
@@ -2,12 +2,17 @@ import { Stream } from "xstream";
 
 export interface ScrollTopRequest {
   position: number;
-  selector: string;
+  selector: "window" | string;
 }
 
 export const scrollTopDriver = (stream: Stream<ScrollTopRequest>): void => {
   stream.addListener({
     next: (request) => {
+      if (request.selector === "window") {
+        window.scroll({ top: request.position });
+        return;
+      }
+
       const selector = document.querySelector(request.selector);
       if (selector) {
         selector.scrollTop = request.position;


### PR DESCRIPTION
scrollTioDriver can scroll only document elements.
This PR allowed the driver to be able to scroll window.